### PR TITLE
Fix CHIP_ANA_POWER register fields STARTUP_POWERUP and LINREG_SIMPLE_POWERUP

### DIFF
--- a/custom-bios/codec_reg.h
+++ b/custom-bios/codec_reg.h
@@ -1,6 +1,12 @@
 #ifndef ROCKLING_REG_H_
 #define ROCKLING_REG_H_
 
+#define BIT(n) (1<<n)
+
+/* ----------------- */
+/* Register addreses */
+/* ----------------- */
+
 #define CHIP_ID             0x0000
 #define CHIP_ANA_ADC_CTRL   0x0020
 #define CHIP_LINREG_CTRL    0x0026
@@ -10,18 +16,60 @@
 #define CHIP_CLK_TOP_CTRL   0x0034
 #define CHIP_SHORT_CTRL     0x003C
 
-#define BIT(n) (1<<n)
+/* ------------------------- */
+/* CHIP_LINREG_CTRL register */
+/* ------------------------- */
 
-/* CHIP_LINREG_CTRL bits */
-#define VDDC_ASSN_OVRD        BIT(5)
-#define VDDC_MAN_ASSN         BIT(6)
+#define VDDC_ASSN_OVRD            BIT(5)
+#define VDDC_MAN_ASSN             BIT(6)
 
-/* CHIP_ANA_POWER bits */
-#define VDDC_CHRGPMP_POWERUP  BIT(11)
-#define LINREG_SIMPLE_POWERUP BIT(12)
-#define STARTUP_POWERUP       BIT(13)
+/* ------------------------------------------------------- */
+/* CHIP_ANA_POWER register, Datasheet page 42-43, table 33 */
+/* ------------------------------------------------------- */
 
-/* CHIP_CLK_TOP_CTRL bits */
+#define LINEOUT_POWERUP           BIT(0)  // 0:off, 1:on
+#define ADC_POWERUP               BIT(1)  // 0:off, 1:on
+#define CAPLESS_HEADPHONE_POWERUP BIT(2)  // 0:off, 1:on
+#define DAC_POWERUP               BIT(3)  // 0:off, 1:on
+#define HEADPHONE_POWERUP         BIT(4)  // 0:off, 1:on
+
+// REFTOP_POWERUP can be off when IC is in sleep state to minimize analog power
+#define REFTOP_POWERUP            BIT(5)  // Reference bias current: 1:on
+
+// ADC_MONO mode is only useful when using the microphone input
+#define ADC_MONO                  BIT(6)  // 0:mono (left only), 1:stereo
+
+// HEADPHONE_POWERUP and/or LINEOUT_POWERUP should be set before clearing
+// VAG_POWERUP and remain set for 200 to 400 ms after VAG_POWERUP cleared
+#define VAG_POWERUP               BIT(7)  // Headphone and LINEOUT powerup ramp
+#define VCOAMP_POWERUP            BIT(8)  // PLL VCO amplifier, 0:off, 1:on
+#define LINREG_D_POWERUP          BIT(9)  // Primary VDDD linear regulator
+
+// CHIP_PLL_CTRL register must be configured before setting PLL_POWERUP
+// PLL_POWERUP must be set before CHIP_CLK_CTRL:MCLK_FREQ is programmed to 0x3
+#define PLL_POWERUP               BIT(10) // 0:off, 1:on
+
+// If both VDDA ond VDDIO are < 3.0 V, then VDDC_CHRGPMP_POWERUP must be cleared
+// before analog blocks are powered up
+// VDDC_CHRGPMP_POWERUP requires either PLL_POWERUP or
+// CLK_TOP_CTRL:ENABLE_INT_OSC
+#define VDDC_CHRGPMP_POWERUP      BIT(11) // Power up the VDDC charge pump block
+
+// STARTUP_POWERUP can be cleared after reest, if VDDD externally powered
+#define STARTUP_POWERUP           BIT(12) // 0:off, 1:on (default)
+
+// STARTUP_POWERUP can be cleared after reest, if VDDD externally powered or
+// the primary digital linear regulator is enabled with LINREG_D_POWERUP
+#define LINREG_SIMPLE_POWERUP     BIT(13) // 0:off, 1:on (default)
+
+// While DAC_POWERUP is set, allows the DAC to be left only mono to save power
+#define DAC_MONO                  BIT(14) // 0:Mono (left), 1:Stereo (default)
+//      RESERVED                  BIT(15)
+
+/* -------------------------- */
+/* CHIP_CLK_TOP_CTRL register */
+/* -------------------------- */
+
 #define ENABLE_INT_OSC        BIT(11)
 
 #endif

--- a/doc/codec.md
+++ b/doc/codec.md
@@ -49,3 +49,12 @@ and their answers (as far as I know) and the consequences:
 7.  Set LINEOUT bias current
     -   CHIP_LINE_OUT_CTRL bits 8:11 (OUT_CURRENT) set to 0x03 (0.36mA)
 8.  ...
+
+Additional notes
+
+- CHIP_PLL_CTRL register must be configured before setting CHIP_ANA_POWER:PLL_POWERUP
+- CHIP_ANA_POWER:PLL_POWERUP must be set before CHIP_CLK_CTRL:MCLK_FREQ is programmed to 0x3
+- If both VDDA ond VDDIO are < 3.0 V, then CHIP_ANA_POWER:VDDC_CHRGPMP_POWERUP must be cleared before analog blocks are powered up
+- CHIP_ANA_POWER:VDDC_CHRGPMP_POWERUP requires either CHIP_ANA_POWER:PLL_POWERUP or CLK_TOP_CTRL:ENABLE_INT_OSC to be set
+- CHIP_ANA_POWER:HEADPHONE_POWERUP and/or CHIP_ANA_POWER:LINEOUT_POWERUP should be set before clearing CHIP_ANA_POWER:VAG_POWERUP and remain set for 200 to 400 ms after CHIP_ANA_POWER:VAG_POWERUP cleared
+- CHIP_ANA_POWER:STARTUP_POWERUP can be cleared after reest, if VDDD externally powered

--- a/rtl/codec_clock.py
+++ b/rtl/codec_clock.py
@@ -2,7 +2,7 @@ from migen import Module
 from migen.fhdl.structure import ClockSignal
 
 class CodecClock(Module):
-    """Provice a master clock signal for the SGTL5000 audio codec"""
+    """Provide a master clock signal for the SGTL5000 audio codec"""
     def __init__(self, pads):
         clk = ClockSignal()
         self.comb += [

--- a/tools/i2c_probe.sh
+++ b/tools/i2c_probe.sh
@@ -1,23 +1,35 @@
 #!/bin/bash
-
-# This script tries to sequentially probe every i2c device on the bus.
+#
+# Scan I2C devices on the bus
+#
+# This will only work on the ...
+# - Rockling prototype  using I2C bus 0
+# - Rockling production using I2C bus 1
 
 csr () {
-	wishbone-tool --csr-csv csr.csv "$@" 2>/dev/null | grep -Fv "Exited MemoryAccess thread"
+  wishbone-tool --csr-csv csr.csv "$@" 2>/dev/null | grep -Fv "Exited MemoryAccess thread"
 }
 
-csr i2c1_core_reset 1  # reset i2c block
+# I2C_BUS=i2c0  # Rockling prototype
+I2C_BUS=i2c1    # Rockling production
 
-# clock prescaler formula is apparently (clk_htz / (5*i2c_htz)) - 1
+csr ${I2C_BUS}_core_reset 1  # reset I2C block
+
+# clock prescaler formula is apparently (clk_htz / (5 * ${I2C_BUS}_htz)) - 1
 # e.g. (12e6 / (5*100e3)) - 1 == 23
-csr i2c1_prescale 23
-csr i2c1_control  0x80 # enable i2c block
 
-for i in `seq 0 127`; do
-	printf "Address: 0x%x\n" $i
-	csr i2c1_txr      $[($i<<1)+0] # address + write
-	csr i2c1_command  0x90 # START and send address command
-	csr i2c1_status        # print status register (tells us if response was ACK or NACK)
-	csr i2c1_txr      0x00 # load one byte of zeros into send register
-	csr i2c1_command  0x50 # send byte and STOP
+csr ${I2C_BUS}_prescale 23
+csr ${I2C_BUS}_control  0x80 # enable I2C block
+
+# DEVICES="`seq 1 127`"      # All potential I2C device addresses
+DEVICES="10 39 96 97 98 99"  # Known Rockling I2C device addresses
+
+for i in $DEVICES; do
+  printf "Address: 0x%x\n" $i
+  csr ${I2C_BUS}_txr      $[($i<<1)+0] # address + write
+  csr ${I2C_BUS}_command  0x90 # START and send address command
+  csr ${I2C_BUS}_status        # print status register
+                               # (tells us if response was ACK or NACK)
+  csr ${I2C_BUS}_txr      0x00 # load one byte of zeros into send register
+  csr ${I2C_BUS}_command  0x50 # send byte and STOP
 done

--- a/tools/i2c_test_pcf8574.sh
+++ b/tools/i2c_test_pcf8574.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Write to PCF8574 I2C 8-bit GPIO bidriectional port
+
+csr () {
+  wishbone-tool --csr-csv csr.csv "$@" 2>/dev/null | grep -Fv "Exited MemoryAccess thread"
+}
+
+# I2C_BUS=i2c0  # Rockling prototype
+I2C_BUS=i2c1    # Rockling production
+
+csr ${I2C_BUS}_core_reset 1  # reset I2C block
+
+# clock prescaler formula is apparently (clk_htz / (5 * ${I2C_BUS}_htz)) - 1
+# e.g. (12e6 / (5*100e3)) - 1 == 23
+
+csr ${I2C_BUS}_prescale 23
+csr ${I2C_BUS}_control  0x80 # enable I2C block
+
+PCF8574_ADDRESS=0x27
+
+pcf8574_write() {
+  DATA=$1
+
+  csr ${I2C_BUS}_txr      $[($PCF8574_ADDRESS<<1)+0] # address + write
+  csr ${I2C_BUS}_command  0x90  # START and send address
+  csr ${I2C_BUS}_status         # print status register
+                                # (tells us if response was ACK or NACK)
+  csr ${I2C_BUS}_txr      $DATA # data byte 0
+  csr ${I2C_BUS}_command  0x10  # send byte
+}
+
+while true; do
+  pcf8574_write 0x00
+  sleep 1
+  pcf8574_write 0x01
+  sleep 1
+done


### PR DESCRIPTION
- CHIP_ANA_POWER register fields STARTUP_POWERUP and LINREG_SIMPLE_POWERUP bit indices were swapped !
- Add new `tools/i2c_test_pcf8574.sh` to control PCF8574 I2C bidirectional 8-bit GPIO port
- Provide Rockling prototype backward compatibility for I2C bus selection in `tools/i2c_probe.sh`
- Some additional notes for `doc/codec.md`